### PR TITLE
Fix slow page load - don't preload audio

### DIFF
--- a/puzzle/script.js
+++ b/puzzle/script.js
@@ -848,7 +848,7 @@ Puzzle.prototype.changeImage = function (imgSrc, audioSrc) {
 
 Puzzle.prototype.setAudio = function (audioSrc) {
   this.audio = new Audio(audioSrc);
-  this.audio.preload = "auto";
+  this.audio.preload = "none";
   this.audioReady = false;
   this.audioPendingPlay = false;
 
@@ -882,6 +882,7 @@ Puzzle.prototype.playAudio = function () {
       this.audio.play();
     } else {
       this.audioPendingPlay = true;
+      this.audio.load();
     }
     clearTimeout(this.playTimeout);
     this.playTimeout = setTimeout(() => {


### PR DESCRIPTION
## Summary
- Change audio preload from "auto" to "none"
- Audio no longer blocks page load (was downloading 66MB)
- Audio starts loading on first piece interaction instead

🤖 Generated with [Claude Code](https://claude.ai/code)